### PR TITLE
Add 3 Methods and 1 Dataset

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,23 +4,26 @@ Unidimensional Total variation (TV) Benchmark
 
 This benchmark is dedicated to solver of TV-1D regularised regression problem:
 
-$$\\boldsymbol{u} \\in \\underset{\\boldsymbol{u} \\in \\mathbb{R}^{p}}{\\mathrm{argmin}} f(\\boldsymbol{y}, A \\boldsymbol{u}) + g(D\\boldsymbol{u})$$
+.. math::
+   \boldsymbol{u} \in \underset{\boldsymbol{u} \in \mathbb{R}^{p}}{\mathrm{argmin}} f(\boldsymbol{y}, A \boldsymbol{u}) + g(D\boldsymbol{u})
 
 
-- $\\boldsymbol{y} \\in \\mathbb{R}^{n}$ is a vector of observations or targets.
-- $A \\in \\mathbb{R}^{n \\times p}$ is a design matrix or forward operator.
-- $\\lambda > 0$ is a regularization hyperparameter.
-- $f(\\boldsymbol{y}, A\\boldsymbol{u}) = \\sum\\limits_{k} l(y_{k}, (A\\boldsymbol{u})_{k})$ is a loss function, where $l$ can be quadratic loss as $l(y, x) = \\frac{1}{2} \\vert y - x \\vert_2^2$, or Huber loss as $l(y, x) = h_{\\delta} (y - x)$ defined by
+- :math:`\boldsymbol{y} \in \mathbb{R}^{n}` is a vector of observations or targets.
+- :math:`A \in \mathbb{R}^{n \times p}` is a design matrix or forward operator.
+- :math:`\lambda > 0` is a regularization hyperparameter.
+- :math:`f(\boldsymbol{y}, A\boldsymbol{u}) = \sum\limits_{k} l(y_{k}, (A\boldsymbol{u})_{k})` is a loss function, where :math:`l` can be quadratic loss as :math:`l(y, x) = \frac{1}{2} \vert y - x \vert_2^2`, or Huber loss as :math:`l(y, x) = h_{\delta} (y - x)` defined by
+
+.. math::
+   h_{\delta}(t) = \begin{cases}
+   \frac{1}{2} t^2 & \mathrm{ if } \vert t \vert \le \delta \\
+   \delta \vert t \vert - \frac{1}{2} \delta^2 & \mathrm{ otherwise}
+   \end{cases}
 
 
-$$   
-h_{\\delta}(t) = \\begin{cases} \\frac{1}{2} t^2 & \\mathrm{ if } \\vert t \\vert \\le \\delta \\\\ \\delta \\vert t \\vert - \\frac{1}{2} \\delta^2 & \\mathrm{ otherwise} \\end{cases}
-$$
+- :math:`D \in \mathbb{R}^{(p-1) \times p}` is a finite difference operator, such that the regularised TV-1D term :math:`g(D\boldsymbol{u}) = \lambda \| \boldsymbol{u} \|_{TV}` expressed as follows.
 
-- $D \\in \\mathbb{R}^{(p-1) \\times p}$ is a finite difference operator, such that the regularised TV-1D term $g(D\\boldsymbol{u}) = \\lambda \\| \\boldsymbol{u} \\|_{TV}$ expressed as follows.
-
-
-$$g(D\\boldsymbol{u}) = \\lambda \\| D \\boldsymbol{u} \\|_{1} = \\lambda \\sum\\limits_{k = 1}^{p-1} \\vert u_{k+1} - u_{k} \\vert $$
+.. math::
+   g(D\boldsymbol{u}) = \lambda \| D \boldsymbol{u} \|_{1} = \lambda \sum\limits_{k = 1}^{p-1} \vert u_{k+1} - u_{k} \vert
 
 
 where n (or `n_samples`) stands for the number of samples, p (or `n_features`) stands for the number of features.

--- a/benchmark_utils/tv_numba.py
+++ b/benchmark_utils/tv_numba.py
@@ -1,0 +1,386 @@
+"""
+Proximity Operator for Total Variation in 1D.
+
+This solve the problem:
+.. math::
+    \min_x \frac{1}{2} \|x - y\|_2^2 + \lambda \|x\|_1
+
+Three implemtation are availables:
+- linearizedTautString: Algorihtm by Condat in O(n)
+-
+"""
+import numpy as np
+
+import numba as nb
+
+nbr1d64 = nb.types.Array(nb.types.float64, 1, "A", readonly=True)
+nbr1d32 = nb.types.Array(nb.types.float32, 1, "A", readonly=True)
+
+nbr2d64 = nb.types.Array(nb.types.float64, 2, "A", readonly=True)
+nbr2d32 = nb.types.Array(nb.types.float32, 2, "A", readonly=True)
+
+nb2d64 = nb.types.Array(nb.types.float64, 2, "A")
+nb2d32 = nb.types.Array(nb.types.float32, 2, "A")
+nb1d64 = nb.types.Array(nb.types.float64, 1, "A")
+nb1d32 = nb.types.Array(nb.types.float32, 1, "A")
+
+nbr1d64c = nb.types.Array(nb.types.complex128, 1, "A", readonly=True)
+nbr1d32c = nb.types.Array(nb.types.complex64, 1, "A", readonly=True)
+
+nbr2d64c = nb.types.Array(nb.types.complex128, 2, "A", readonly=True)
+nbr2d32c = nb.types.Array(nb.types.complex64, 2, "A", readonly=True)
+
+nb2d64c = nb.types.Array(nb.types.complex128, 2, "A")
+nb2d32c = nb.types.Array(nb.types.complex64, 2, "A")
+nb1d64c = nb.types.Array(nb.types.complex128, 1, "A")
+nb1d32c = nb.types.Array(nb.types.complex64, 1, "A")
+
+
+@nb.njit(nb1d32(nbr1d32, nb.types.float32, nb1d32))
+def linearizedTautString(y, lmbd, x):
+    """Linearized Taut String algorithm.
+
+    Follows the algorithm described in [1]_, analoguous to the Condat algorithm [2]_.
+    Parameters
+    ----------
+    y: np.ndarray
+        Input data.
+    lambda: float
+        Regularization parameter.
+    x: np.ndarray
+        Return value
+
+    Returns
+    -------
+    np.ndarray
+        Output data.
+
+    References
+    ----------
+    .. [1] https://github.com/albarji/proxTV/blob/master/src/TVL1opt.cpp
+    .. [2] Condat, L. (2013). A direct algorithm for 1D total variation denoising.
+    """
+
+    i = 0
+    mnHeight = mxHeight = 0
+    mn = y[0] - lmbd
+    mx = y[0] + lmbd
+    lastBreak = -1
+    mnBreak = mxBreak = 0
+    N = len(y)
+    while i < N:
+        while i < N - 1:
+            mnHeight += mn - y[i]
+            if lmbd < mnHeight:
+                i = mnBreak + 1
+                x[lastBreak + 1 : mnBreak + 1] = mn
+                lastBreak = mnBreak
+                mn = y[i]
+                mx = 2 * lmbd + mn
+                mxHeight = lmbd
+                mnHeight = -lmbd
+                mnBreak = mxBreak = i
+                i += 1
+                continue
+            mxHeight += mx - y[i]
+            if -lmbd > mxHeight:
+                i = mxBreak + 1
+                x[lastBreak + 1 : mxBreak + 1] = mx
+                lastBreak = mxBreak
+                mx = y[i]
+                mn = mx - 2 * lmbd
+                mnHeight = lmbd
+                mxHeight = -lmbd
+                mnBreak = mxBreak = i
+                i += 1
+                continue
+            if mxHeight > lmbd:
+                mx += (lmbd - mxHeight) / (i - lastBreak)
+                mxHeight = lmbd
+                mxBreak = i
+            if mnHeight <= -lmbd:
+                mn += (-lmbd - mnHeight) / (i - lastBreak)
+                mnHeight = -lmbd
+                mnBreak = i
+            i += 1
+        mnHeight += mn - y[i]
+        if mnHeight > 0:
+            i = mnBreak + 1
+            x[lastBreak + 1 : mnBreak + 1] = mn
+            lastBreak = mnBreak
+            mn = y[i]
+            mx = 2 * lmbd + mn
+            mxHeight = mnHeight = -lmbd
+            mnBreak = mxBreak = i
+            continue
+        mxHeight += mx - y[i]
+        if mxHeight < 0:
+            i = mxBreak + 1
+            x[lastBreak + 1 : mxBreak + 1] = mx
+            lastBreak = mxBreak
+            mx = y[i]
+            mn = mx - 2 * lmbd
+            mnHeight = mxHeight = lmbd
+            mnBreak = mxBreak = i
+            continue
+        if mnHeight <= 0:
+            mn += (-mnHeight) / (i - lastBreak)
+        i += 1
+    x[lastBreak + 1 :] = mn
+    return x
+
+#######################################
+#   ProxTV 1D using an MM algorithm   #
+#######################################
+
+
+@nb.njit(
+    [
+        nb.types.float32(nbr1d32, nb1d32, nb1d32, nb.types.float32),
+        nb.types.float64(nbr1d64, nb1d64, nb1d64, nb.types.float64),
+    ],
+    fastmath=True,
+)
+def fast_cost(y, x, r, lmbd):
+    return 0.5 * np.sqrt(np.sum(np.abs(y - x) ** 2)) + lmbd * np.sum(r)
+
+
+@nb.njit(
+    [
+        nb1d32(nb1d32),
+        nb1d64(nb1d64),
+    ],
+    fastmath=True,
+)
+def difft(x):
+    """Apply the matrix D^T to x.
+
+    Parameters
+    ----------
+    x: np.ndarray
+        Input data.
+
+    Returns
+    -------
+    np.ndarray
+        Output data.
+
+    Notes
+    -----
+    This function is equivalent to:
+    ..math ::
+        y = \begin{bmatrix}
+        -1 & 1  & 0  & \dots & 0 \\
+        0 & \ddots & \ddots &  \ddots &  \vdots \\
+        \vdots & \ddots & \ddots &  \ddots &  0 \\
+        0 & \dots & 0 & -1 & 1 \\
+        \end{bmatrix}^T x
+    """
+    y = np.zeros(len(x) + 1, dtype=x.dtype)
+    y[0] = -x[0]
+    y[1:-1] = x[:-1] - x[1:]
+    y[-1] = x[-1]
+    return y
+
+
+@nb.njit(
+    ["void(f8[:],f8[:],f8[:],f8[:],f8[:])", "void(f4[:],f4[:],f4[:],f4[:],f4[:])"],
+    fastmath=True,
+)
+def TDMA(a, b, c, d, x):
+    """
+    Solve a tridiagonal system of equations.
+
+    Parameters
+    ----------
+    a: np.ndarray
+        Lower diagonal.
+    b: np.ndarray
+        Diagonal.
+    c: np.ndarray
+        Upper diagonal.
+    d: np.ndarray
+        Right hand side.
+    x: np.ndarray
+        Solution.
+
+    Notes
+    -----
+    This function is equivalent to:
+    ..math ::
+        \begin{bmatrix}
+        b_0 & c_0 & 0 & \dots & 0 \\
+        a_1 & b_1 & c_1 & \dots & 0 \\
+        0 & a_2 & b_2 & \dots & 0 \\
+        \vdots & \ddots & \ddots & \ddots & \vdots \\
+        0 & \dots & 0 & a_{n-1} & b_{n-1} \\
+        \end{bmatrix}
+        \begin{bmatrix} x_0 \\ x_1 \\ \vdots \\   x_{n-1}\end{bmatrix} =
+        \begin{bmatrix} d_0 \\ d_1 \\ \vdots \\ d_{n-1} \\\end{bmatrix}
+    See [1]_ for more details. This function is based on the implementation in [2]_.
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Tridiagonal_matrix_algorithm
+    .. [2] https://stackoverflow.com/questions/8733015
+    """
+
+    n = len(d)
+    w = np.zeros(n - 1, a.dtype)
+    g = np.zeros(n, a.dtype)
+
+    w[0] = c[0] / b[0]
+    g[0] = d[0] / b[0]
+
+    for i in range(1, n - 1):
+        w[i] = c[i] / (b[i] - a[i - 1] * w[i - 1])
+    for i in range(1, n):
+        g[i] = (d[i] - a[i - 1] * g[i - 1]) / (b[i] - a[i - 1] * w[i - 1])
+    x[n - 1] = g[n - 1]
+    for i in range(n - 1, 0, -1):
+        x[i - 1] = g[i - 1] - w[i - 1] * x[i]
+
+
+@nb.njit(
+    [
+        nb1d32(nbr1d32, nb.types.float32, nb.types.int16, nb.types.float32),
+        nb1d64(nbr1d64, nb.types.float64, nb.types.int16, nb.types.float64),
+    ]
+)
+def tv_mm(y, lmbd, max_iter=100, tol=1e-3):
+    N = len(y)
+    ddt_up = -np.ones(N - 1, dtype=y.dtype)
+    ddt_diag = 2 * np.ones(N - 1, dtype=y.dtype)
+    ddt_down = -np.ones(N - 1, dtype=y.dtype)
+    ddt_up[-1] = 0
+    ddt_down[0] = 0
+
+    x = np.copy(y)
+    tmp = np.zeros(N - 1, dtype=y.dtype)
+    diffy = y[1:] - y[:-1]
+    cost_prev = 1e40
+    for i in range(max_iter):
+        tmp = np.abs(x[1:] - x[:-1])
+        if np.all(tmp == 0):
+            break
+        # cost =  0.5 * np.sqrt(np.sum(np.abs(y - x)**2)) + lmbd * np.sum(tmp)
+        cost = fast_cost(y, x, tmp, lmbd)
+        f_diag = (tmp / lmbd) + ddt_diag
+        TDMA(ddt_down, f_diag, ddt_up, diffy, tmp)
+        x = y - difft(tmp)
+        if (cost_prev - cost) / cost_prev <= tol:
+            break
+        else:
+            cost_prev = cost
+    return x
+
+
+
+@nb.njit(
+    [nb1d32(nb1d32, nb.types.int16), nb1d64(nb1d64, nb.types.int16)],
+    fastmath=True,
+    error_model="numpy",
+)
+def running_sum_valid(arr, K):
+    """Compute the running sum of an array.
+
+    This is equivalent to `np.convolve(a, np.ones(K), mode='same')`,
+    and is slighly faster for our usecase.
+    This reimplementation is necessary to enable numba to properly compile
+    the gtv function.
+    """
+    N = len(arr)
+    ret = np.empty(N, arr.dtype)
+    i = 0
+    r = K // 2
+    running_buf = np.zeros(K + 1, arr.dtype)
+    running_buf[: K // 2] = arr[: K // 2]
+    s = np.sum(running_buf)
+    while i < N:
+        if i + K // 2 >= N:
+            running_buf[r] = 0
+        else:
+            running_buf[r] = arr[i + K // 2]
+        s += running_buf[r]
+        r = (r + 1) % (K + 1)
+        s -= running_buf[r]
+        ret[i] = s
+        i += 1
+    return ret
+
+
+@nb.njit(
+    [
+        nb.types.Array(nb.types.float64, 1, "A")(
+            nbr1d64,
+            nb.types.float64,
+            nb.types.int16,
+            nb.types.int16,
+            nb.types.float64,
+        ),
+        nb.types.Array(nb.types.float32, 1, "A")(
+            nbr1d32,
+            nb.types.float32,
+            nb.types.int16,
+            nb.types.int16,
+            nb.types.float32,
+        ),
+    ],
+    error_model="numpy",
+)
+def gtv_mm_tol2(y, lmbd, K=1, max_iter=100, tol=1e-3):
+    """Group Total Variation denoising using the Majoration-Minimization algorithm.
+
+    Parameters
+    ----------
+    y : np.ndarray
+        Input data.
+    lmbd : float
+        Regularization parameter.
+    K : int
+        Size of the group.
+    max_iter : int
+        Maximum number of iterations.
+    tol : float
+        Tolerance for the stopping criterion.
+
+    Returns
+    -------
+    np.ndarray
+        Output data.
+
+    References
+    ----------
+    .. [1]  I. W. Selesnick and P.-Y. Chen, “Total variation denoising with overlapping
+      group sparsity” in 2013 IEEE International Conference on Acoustics, Speech and
+      Signal Processing, Vancouver, BC, Canada, May 2013, pp. 5696–5700.
+      doi: 10.1109/ICASSP.2013.6638755.
+    """
+    N = len(y)
+    ddt_up = -np.ones(N - 1, dtype=y.dtype)
+    ddt_diag = 2 * np.ones(N - 1, dtype=y.dtype)
+    ddt_down = -np.ones(N - 1, dtype=y.dtype)
+    f_diag = np.empty_like(y)
+    x = y.copy()
+    tmp = np.zeros(N - 1, dtype=y.dtype)
+    diffy = y[1:] - y[:-1]
+    cost_prev = 1e40
+    for i in range(max_iter):
+        tmp = (x[1:] - x[:-1]) ** 2
+        if np.min(tmp) < 1e-10:
+            break
+        tmp = running_sum_valid(tmp, K)
+        tmp = np.sqrt(tmp)
+        # cost =  0.5 * np.sqrt(np.sum(np.abs(y - x)**2)) + lmbd * np.sum(tmp)
+        cost = fast_cost(y, x, tmp, lmbd)
+        tmp = 1 / tmp
+        tmp = running_sum_valid(tmp, K)
+        f_diag = 1 / (tmp * lmbd) + ddt_diag
+        TDMA(ddt_down, f_diag, ddt_up, diffy, tmp)
+        x = y - difft(tmp)
+        if (cost_prev - cost) <= tol * cost_prev:
+            break
+        else:
+            cost_prev = cost
+    return x
+

--- a/benchmark_utils/tv_numba.py
+++ b/benchmark_utils/tv_numba.py
@@ -36,7 +36,8 @@ nb1d64c = nb.types.Array(nb.types.complex128, 1, "A")
 nb1d32c = nb.types.Array(nb.types.complex64, 1, "A")
 
 
-@nb.njit(nb1d32(nbr1d32, nb.types.float32, nb1d32))
+@nb.njit([nb1d32(nbr1d32, nb.types.float32, nb1d32),
+          nb1d64(nbr1d64, nb.types.float64, nb1d64),])
 def linearizedTautString(y, lmbd, x):
     """Linearized Taut String algorithm.
 

--- a/datasets/hrf.py
+++ b/datasets/hrf.py
@@ -1,0 +1,79 @@
+from benchopt import BaseDataset
+from benchopt import safe_import_context
+
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from nilearn.glm.first_level import compute_regressor
+    from scipy.sparse.linalg import LinearOperator
+
+class Dataset(BaseDataset):
+    """Dataset modeling a block designed BOLD fMRI time serie."""
+    name = "HRF"
+
+    parameters = {
+        'sim_tr': [1.0], # time resolution in ms
+        'block_on': [10], # time on in seconds
+        'block_off': [10], # time off in seconds
+        'n_blocks': [5], # number of blocks
+        'use_hrf': [True, False], # If the data is convolve with an HRF.
+        'noise_level': [0.1, 0.5, 1, 2, 5, 10], # noise level
+        'random_state': [42],
+}
+    requirements = ['pip:nilearn']
+
+    def __init__(self, sim_tr=1, n_blocks=2, block_on=10, block_off=20,  use_hrf=True, noise_level=0.1, random_state=42):
+        self.sim_tr = sim_tr
+        self.n_blocks = n_blocks
+        self.block_on = block_on
+        self.block_off = block_off
+        self.use_hrf = use_hrf
+        self.noise_level = noise_level
+        self.random_state = random_state
+
+    def get_data(self):
+        rng = np.random.RandomState(self.random_state)
+        block_size = self.block_on + self.block_off
+        n_samples = self.n_blocks *block_size
+        duration = self.sim_tr * n_samples
+
+        #create a repeating block design
+        event = []
+        t = 0
+        while t < duration:
+            event.append((t,self.block_on, 1))
+            t += block_size
+        events = np.array(event)
+        if self.use_hrf:
+            regressor, _ = compute_regressor(
+                events.T,
+                "glover",
+                np.arange(0,n_samples) * self.sim_tr,
+                oversampling=50,
+                min_onset=-24,
+            )
+            regressor = np.squeeze(regressor)
+        else:
+            regressor = np.zeros(n_samples)
+            while t < duration:
+                regressor[t:t+self.block_on] = 1
+                t += block_size
+
+        # Add noise
+        noise = rng.randn(n_samples)
+        noise *= np.linalg.norm(regressor) * self.noise_level
+        regressor_noise = regressor + noise
+
+        # A = Identity
+        # y = A x + noise
+
+        return {"A": LinearOperator(
+            dtype=np.float64,
+            matvec=lambda x: x,
+            matmat=lambda X: X,
+            rmatvec=lambda x: x,
+            rmatmat=lambda X: X,
+            shape=(n_samples, n_samples),
+        ),
+           "y": regressor_noise,
+           "x": regressor}

--- a/solvers/condat_linear.py
+++ b/solvers/condat_linear.py
@@ -1,0 +1,32 @@
+from benchopt import BaseSolver
+from benchopt import safe_import_context
+from benchopt.stopping_criterion import SingleRunCriterion
+with safe_import_context() as import_ctx:
+    import numpy as np
+    import numba as nb
+    from benchmark_utils.tv_numba import linearizedTautString
+
+class Solver(BaseSolver):
+    """Solve the TV minimization problem using a majorization-minimization algorithm."""
+
+    name = 'tv_mm'
+    stopping_strategy = SingleRunCriterion()
+
+    def set_objective(self, A, reg, y, c , delta, data_fit):
+        self.reg = reg
+        self.A, self.y = A, y
+        self.c = c
+        self.data_fit = data_fit
+        # Delta is ignored, only used for huber function.
+        self.run(5)
+
+    def skip(self, **objective_dict):
+        if objective_dict['data_fit'] != 'quad':
+            return True, "TVMM solver only useable for quadratic data_fit"
+        return False, None
+
+    def run(self, n_iter):
+        self.u = linearizedTautString(self.y, self.reg)
+
+    def get_result(self):
+        return self.u

--- a/solvers/condat_linear.py
+++ b/solvers/condat_linear.py
@@ -9,7 +9,7 @@ with safe_import_context() as import_ctx:
 class Solver(BaseSolver):
     """Solve the TV minimization problem using a majorization-minimization algorithm."""
 
-    name = 'tv_mm'
+    name = 'Linearized Taut String'
     stopping_strategy = SingleRunCriterion()
 
     def set_objective(self, A, reg, y, c , delta, data_fit):

--- a/solvers/condat_linear.py
+++ b/solvers/condat_linear.py
@@ -10,7 +10,7 @@ class Solver(BaseSolver):
     """Solve the TV minimization problem using a majorization-minimization algorithm."""
 
     name = 'Linearized Taut String'
-    stopping_strategy = SingleRunCriterion()
+    stopping_criterion = SingleRunCriterion()
 
     def set_objective(self, A, reg, y, c , delta, data_fit):
         self.reg = reg
@@ -26,7 +26,8 @@ class Solver(BaseSolver):
         return False, None
 
     def run(self, n_iter):
-        self.u = linearizedTautString(self.y, self.reg)
+        self.u = np.zeros_like(self.y)
+        linearizedTautString(self.y, self.reg, self.u)
 
     def get_result(self):
         return self.u

--- a/solvers/gtv_mm.py
+++ b/solvers/gtv_mm.py
@@ -1,0 +1,33 @@
+from benchopt import BaseSolver
+from benchopt import safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from benchmark_utils.tv_numba import gtv_mm_tol2
+
+class Solver(BaseSolver):
+    """Solve the TV minimization problem using a majorization-minimization algorithm."""
+
+    name = 'gtv_mm'
+    stopping_strategy = 'iteration'
+    parameters = {"tol": [1e-3, 1e-4, 1e-5, 1e-6],
+                  "K": [1, 2, 3, 4, 5]}
+
+    def set_objective(self, A, reg, y, c , delta, data_fit):
+        self.reg = reg
+        self.A, self.y = A, y
+        self.c = c
+        self.data_fit = data_fit
+        # Delta is ignored, only used for huber function.
+        self.run(5)
+
+    def skip(self, **objective_dict):
+        if objective_dict['data_fit'] != 'quad':
+            return True, "TVMM solver only useable for quadratic data_fit"
+        return False, None
+
+    def run(self, n_iter):
+        self.u = gtv_mm_tol2(self.y, self.reg, self.K, n_iter,self.tol)
+
+    def get_result(self):
+        return self.u

--- a/solvers/gtv_mm.py
+++ b/solvers/gtv_mm.py
@@ -8,7 +8,7 @@ with safe_import_context() as import_ctx:
 class Solver(BaseSolver):
     """Solve the TV minimization problem using a majorization-minimization algorithm."""
 
-    name = 'gtv_mm'
+    name = 'Group TV MM'
     stopping_strategy = 'iteration'
     parameters = {"tol": [1e-3, 1e-4, 1e-5, 1e-6],
                   "K": [1, 2, 3, 4, 5]}

--- a/solvers/tv_mm.py
+++ b/solvers/tv_mm.py
@@ -1,0 +1,33 @@
+from benchopt import BaseSolver
+from benchopt import safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    import numba as nb
+    from benchmark_utils.tv_numba import tv_mm, gtv_mm_tol2, linearizedTautString
+
+class Solver(BaseSolver):
+    """Solve the TV minimization problem using a majorization-minimization algorithm."""
+
+    name = 'tv_mm'
+    stopping_strategy = 'iteration'
+    parameters = {"tol": [1e-3, 1e-4, 1e-5, 1e-6]}
+
+    def set_objective(self, A, reg, y, c , delta, data_fit):
+        self.reg = reg
+        self.A, self.y = A, y
+        self.c = c
+        self.data_fit = data_fit
+        # Delta is ignored, only used for huber function.
+        self.run(5)
+
+    def skip(self, **objective_dict):
+        if objective_dict['data_fit'] != 'quad':
+            return True, "TVMM solver only useable for quadratic data_fit"
+        return False, None
+
+    def run(self, n_iter):
+        self.u = tv_mm(self.y, self.reg, n_iter,self.tol)
+
+    def get_result(self):
+        return self.u


### PR DESCRIPTION
Hi, 

This PR add 3 Method to solve the TV1D denoising problem: 
1) The linear taut String method
2) A MM algorithm
3) A Group TV method (the L1 norm is replaced by a Group l1, similar to what Group LASSO is to LASSO). It is not strictly the TV problem, but is close enough to be integrated IMO.

Also I added a simulated dataset, which create a BOLD-fMRI times series (basically a block wise signal, convolve with an HRF). Note that linear operator is still the Identity, and the data-fit is restricted to quadratic. 

Github does not support to embed HTML, so the results are here: https://perso.crans.org/comby/neurospin/benchmark_tv_1d_benchopt_run_2023-07-03_14h39m15.html