### PR TITLE
FIX Escape underscores in latex in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,10 @@ $$\\boldsymbol{u} \\in \\underset{\\boldsymbol{u} \\in \\mathbb{R}^{p}}{\\mathrm
 - $\\lambda > 0$ is a regularization hyperparameter.
 - $f(\\boldsymbol{y}, A\\boldsymbol{u}) = \\sum\\limits_{k} l(y_{k}, (A\\boldsymbol{u})_{k})$ is a loss function, where $l$ can be quadratic loss as $l(y, x) = \\frac{1}{2} \\vert y - x \\vert_2^2$, or Huber loss as $l(y, x) = h_{\\delta} (y - x)$ defined by
 
+$A_u$
+$A\_u$
 
-$$   
+$$
 h_{\\delta}(t) = \\begin{cases} \\frac{1}{2} t^2 & \\mathrm{ if } \\vert t \\vert \\le \\delta \\\\ \\delta \\vert t \\vert - \\frac{1}{2} \\delta^2 & \\mathrm{ otherwise} \\end{cases}
 $$
 
@@ -36,7 +38,7 @@ This benchmark can be run using the following commands:
 
    $ pip install -U benchopt
    $ git clone https://github.com/benchopt/benchmark_tv_1d
-   $ benchopt run benchmark_tv_1d 
+   $ benchopt run benchmark_tv_1d
 
 Apart from the problem, options can be passed to `benchopt run`, to restrict the benchmarks to some solvers or datasets, e.g.:
 

--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,9 @@ $$\\boldsymbol{u} \\in \\underset{\\boldsymbol{u} \\in \\mathbb{R}^{p}}{\\mathrm
 $A_u$
 $A_u A_u$
 
+$l(y, x) = h_{\\delta} (y - x)$
+$l(y, x) = h\_{\\delta} (y - x)$
+
 $A\_u$
 $A\_u A \_u$
 $\\| \\boldsymbol{u} \\|_{TV}$

--- a/README.rst
+++ b/README.rst
@@ -10,26 +10,17 @@ $$\\boldsymbol{u} \\in \\underset{\\boldsymbol{u} \\in \\mathbb{R}^{p}}{\\mathrm
 - $\\boldsymbol{y} \\in \\mathbb{R}^{n}$ is a vector of observations or targets.
 - $A \\in \\mathbb{R}^{n \\times p}$ is a design matrix or forward operator.
 - $\\lambda > 0$ is a regularization hyperparameter.
-- $f(\\boldsymbol{y}, A\\boldsymbol{u}) = \\sum\\limits\_{k} l(y\_{k}, (A\\boldsymbol{u})_{k})$ is a loss function, where $l$ can be quadratic loss as $l(y, x) = \\frac{1}{2} \\vert y - x \\vert_2^2$, or Huber loss as $l(y, x) = h_{\\delta} (y - x)$ defined by
+- $f(\\boldsymbol{y}, A\\boldsymbol{u}) = \\sum\\limits\_{k} l(y\_{k}, (A\\boldsymbol{u})_{k})$ is a loss function, where $l$ can be quadratic loss as $l(y, x) = \\frac{1}{2} \\vert y - x \\vert_2^2$, or Huber loss as $l(y, x) = h\_{\\delta} (y - x)$ defined by
 
-$A_u$
-$A_u A_u$
-
-$l(y, x) = h_{\\delta} (y - x)$
-$l(y, x) = h\_{\\delta} (y - x)$
-
-$A\_u$
-$A\_u A \_u$
-$\\| \\boldsymbol{u} \\|_{TV}$
 
 $$
-h_{\\delta}(t) = \\begin{cases} \\frac{1}{2} t^2 & \\mathrm{ if } \\vert t \\vert \\le \\delta \\\\ \\delta \\vert t \\vert - \\frac{1}{2} \\delta^2 & \\mathrm{ otherwise} \\end{cases}
+h\_{\\delta}(t) = \\begin{cases} \\frac{1}{2} t^2 & \\mathrm{ if } \\vert t \\vert \\le \\delta \\\\ \\delta \\vert t \\vert - \\frac{1}{2} \\delta^2 & \\mathrm{ otherwise} \\end{cases}
 $$
 
 - $D \\in \\mathbb{R}^{(p-1) \\times p}$ is a finite difference operator, such that the regularised TV-1D term $g(D\\boldsymbol{u}) = \\lambda \\| \\boldsymbol{u} \\|_{TV}$ expressed as follows.
 
 
-$$g(D\\boldsymbol{u}) = \\lambda \\| D \\boldsymbol{u} \\|_{1} = \\lambda \\sum\\limits_{k = 1}^{p-1} \\vert u_{k+1} - u_{k} \\vert $$
+$$g(D\\boldsymbol{u}) = \\lambda \\| D \\boldsymbol{u} \\|\_{1} = \\lambda \\sum\\limits\_{k = 1}^{p-1} \\vert u\_{k+1} - u\_{k} \\vert $$
 
 
 where n (or `n_samples`) stands for the number of samples, p (or `n_features`) stands for the number of features.

--- a/README.rst
+++ b/README.rst
@@ -10,10 +10,14 @@ $$\\boldsymbol{u} \\in \\underset{\\boldsymbol{u} \\in \\mathbb{R}^{p}}{\\mathrm
 - $\\boldsymbol{y} \\in \\mathbb{R}^{n}$ is a vector of observations or targets.
 - $A \\in \\mathbb{R}^{n \\times p}$ is a design matrix or forward operator.
 - $\\lambda > 0$ is a regularization hyperparameter.
-- $f(\\boldsymbol{y}, A\\boldsymbol{u}) = \\sum\\limits_{k} l(y_{k}, (A\\boldsymbol{u})_{k})$ is a loss function, where $l$ can be quadratic loss as $l(y, x) = \\frac{1}{2} \\vert y - x \\vert_2^2$, or Huber loss as $l(y, x) = h_{\\delta} (y - x)$ defined by
+- $f(\\boldsymbol{y}, A\\boldsymbol{u}) = \\sum\\limits\_{k} l(y\_{k}, (A\\boldsymbol{u})_{k})$ is a loss function, where $l$ can be quadratic loss as $l(y, x) = \\frac{1}{2} \\vert y - x \\vert_2^2$, or Huber loss as $l(y, x) = h_{\\delta} (y - x)$ defined by
 
 $A_u$
+$A_u A_u$
+
 $A\_u$
+$A\_u A \_u$
+$\\| \\boldsymbol{u} \\|_{TV}$
 
 $$
 h_{\\delta}(t) = \\begin{cases} \\frac{1}{2} t^2 & \\mathrm{ if } \\vert t \\vert \\le \\delta \\\\ \\delta \\vert t \\vert - \\frac{1}{2} \\delta^2 & \\mathrm{ otherwise} \\end{cases}


### PR DESCRIPTION
see corrected rendering here : https://github.com/mathurinm/benchmark_tv_1d/tree/readme?tab=readme-ov-file#unidimensional-total-variation-tv-benchmark